### PR TITLE
Fix potential bug in operation precedence building sdp strings.

### DIFF
--- a/lib/tosdp.js
+++ b/lib/tosdp.js
@@ -132,7 +132,7 @@ exports.toMediaSDP = function (content, opts) {
         if (payload.feedback) {
             payload.feedback.forEach(function (fb) {
                 if (fb.type === 'trr-int') {
-                    sdp.push('a=rtcp-fb:' + payload.id + ' trr-int ' + fb.value ? fb.value : '0');
+                    sdp.push('a=rtcp-fb:' + payload.id + ' trr-int ' + (fb.value ? fb.value : '0'));
                 } else {
                     sdp.push('a=rtcp-fb:' + payload.id + ' ' + fb.type + (fb.subtype ? ' ' + fb.subtype : ''));
                 }
@@ -143,7 +143,7 @@ exports.toMediaSDP = function (content, opts) {
     if (desc.feedback) {
         desc.feedback.forEach(function (fb) {
             if (fb.type === 'trr-int') {
-                sdp.push('a=rtcp-fb:* trr-int ' + fb.value ? fb.value : '0');
+                sdp.push('a=rtcp-fb:* trr-int ' + (fb.value ? fb.value : '0'));
             } else {
                 sdp.push('a=rtcp-fb:* ' + fb.type + (fb.subtype ? ' ' + fb.subtype : ''));
             }


### PR DESCRIPTION
So, I don't really know what this module does exactly :), but I noticed uglify was saying that a certain conditional was always true, so I looked at it a little closer, and it does look like there's a potential bug here.

The + operator has a higher precedence than ?, meaning that `'asdf' + boolean ? 'foo' : 'bar'` will always return `'foo'` instead of `asdffoo` or `asdfbar`.