### PR TITLE
hardcode msid-semantic line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - '0.10'

--- a/lib/tosdp.js
+++ b/lib/tosdp.js
@@ -11,7 +11,8 @@ exports.toSessionSDP = function (session, opts) {
         'v=0',
         'o=- ' + sid + ' ' + time + ' IN IP4 0.0.0.0',
         's=-',
-        't=0 0'
+        't=0 0',
+        'a=msid-semantic: WMS *'
     ];
 
     var groups = session.groups || [];

--- a/test/data/sdp.js
+++ b/test/data/sdp.js
@@ -3,6 +3,7 @@ module.exports = [
     "o=- 1382398245712 1385147470924 IN IP4 0.0.0.0",
     "s=-",
     "t=0 0",
+    "a=msid-semantic: WMS *",
     "a=group:BUNDLE audio video",
     "m=audio 1 RTP/SAVPF 111 103 104 0 8 107 106 105 13 126",
     "c=IN IP4 0.0.0.0",


### PR DESCRIPTION
firefox ignores the a=msid: line otherwise.